### PR TITLE
Add support for latest Guzzle 6.1.0 HTTP library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.0"
+        "guzzlehttp/guzzle": ">=5.0 <=6.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",


### PR DESCRIPTION
In order to be able to use this library with other plugins (for example league/oauth2-client) Guzzle ~6.0 is required and from the looks, this library has no issue working with Guzzle 6.