### PR TITLE
Fix error logging multiple messages

### DIFF
--- a/ApplicationInsights/Telemetry_Client.php
+++ b/ApplicationInsights/Telemetry_Client.php
@@ -279,5 +279,6 @@ class Telemetry_Client
     public function flush()
     {
         $this->_channel->send();
+        $this->_channel->setQueue([]);
     }
 }


### PR DESCRIPTION
I have an issue when logging multiple messages using the same instance of TelemetryClient. After logging a message and calling the method flush(), if I call the method flush() again the previously sent message is sent again. Emptying the queue after sending the message seems to fix my issue.