### PR TITLE
Update to support latest Guzzle library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=5.0 <=6.1.0"
+        "guzzlehttp/guzzle": ">=5.0 <=6.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",


### PR DESCRIPTION
Since Guzzle receives continuous updates, it is good to support the latest stable version so there aren't issues with using this library with other library which requires the latest Guzzle.