### PR TITLE
'ExceptionDetails' is too long. Expected: 1024 characters

### DIFF
--- a/ApplicationInsights/Channel/Contracts/Exception_Details.php
+++ b/ApplicationInsights/Channel/Contracts/Exception_Details.php
@@ -2,17 +2,19 @@
 namespace ApplicationInsights\Channel\Contracts;
 
 /**
-* Data contract class for type Exception_Details. 
+* Data contract class for type Exception_Details.
 */
 class Exception_Details
 {
+    const MAX_MESSAGE_SIZE = 1024;
+
     /**
-    * Data array that will store all the values. 
+    * Data array that will store all the values.
     */
     private $_data;
 
     /**
-    * Creates a new ExceptionDetails. 
+    * Creates a new ExceptionDetails.
     */
     function __construct()
     {
@@ -22,7 +24,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the id field. 
+    * Gets the id field.
     */
     public function getId()
     {
@@ -31,7 +33,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the id field. 
+    * Sets the id field.
     */
     public function setId($id)
     {
@@ -39,7 +41,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the outerId field. 
+    * Gets the outerId field.
     */
     public function getOuterId()
     {
@@ -48,7 +50,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the outerId field. 
+    * Sets the outerId field.
     */
     public function setOuterId($outerId)
     {
@@ -56,7 +58,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the typeName field. 
+    * Gets the typeName field.
     */
     public function getTypeName()
     {
@@ -65,7 +67,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the typeName field. 
+    * Sets the typeName field.
     */
     public function setTypeName($typeName)
     {
@@ -73,7 +75,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the message field. 
+    * Gets the message field.
     */
     public function getMessage()
     {
@@ -82,15 +84,17 @@ class Exception_Details
     }
 
     /**
-    * Sets the message field. 
+    * Sets the message field.
     */
     public function setMessage($message)
     {
-        $this->_data['message'] = $message;
+        $this->_data['message'] = strlen($message) > self::MAX_MESSAGE_SIZE ?
+            substr($message, self::MAX_MESSAGE_SIZE) :
+            $message;
     }
 
     /**
-    * Gets the hasFullStack field. 
+    * Gets the hasFullStack field.
     */
     public function getHasFullStack()
     {
@@ -99,7 +103,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the hasFullStack field. 
+    * Sets the hasFullStack field.
     */
     public function setHasFullStack($hasFullStack)
     {
@@ -107,7 +111,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the stack field. 
+    * Gets the stack field.
     */
     public function getStack()
     {
@@ -116,7 +120,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the stack field. 
+    * Sets the stack field.
     */
     public function setStack($stack)
     {
@@ -124,7 +128,7 @@ class Exception_Details
     }
 
     /**
-    * Gets the parsedStack field. 
+    * Gets the parsedStack field.
     */
     public function getParsedStack()
     {
@@ -133,7 +137,7 @@ class Exception_Details
     }
 
     /**
-    * Sets the parsedStack field. 
+    * Sets the parsedStack field.
     */
     public function setParsedStack($parsedStack)
     {
@@ -141,7 +145,7 @@ class Exception_Details
     }
 
     /**
-    * Overrides JSON serialization for this class. 
+    * Overrides JSON serialization for this class.
     */
     public function jsonSerialize()
     {

--- a/ApplicationInsights/Channel/Contracts/Exception_Details.php
+++ b/ApplicationInsights/Channel/Contracts/Exception_Details.php
@@ -89,7 +89,7 @@ class Exception_Details
     public function setMessage($message)
     {
         $this->_data['message'] = strlen($message) > self::MAX_MESSAGE_SIZE ?
-            substr($message, self::MAX_MESSAGE_SIZE) :
+            substr($message, 0, self::MAX_MESSAGE_SIZE) :
             $message;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=5.0 <=6.2.0"
+        "guzzlehttp/guzzle": "^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",


### PR DESCRIPTION
I have an issue when logging a message with more than 1024 characters using Exceptions_Details. You need to cut the exception message because otherwise the app gives a 500 error.