### PR TITLE
Fix unit tests in PHP 7.1

### DIFF
--- a/ApplicationInsights/Channel/Contracts/Utils.php
+++ b/ApplicationInsights/Channel/Contracts/Utils.php
@@ -60,7 +60,7 @@ class Utils
      */
     public static function convertMillisecondsToTimeSpan($milliseconds)
     {
-        if ($milliseconds == NULL || $milliseconds < 0) 
+        if ($milliseconds == NULL || $milliseconds < 0 || !is_numeric($milliseconds))
         {
             $milliseconds = 0;
         }


### PR DESCRIPTION
This isn't numeric https://github.com/Microsoft/ApplicationInsights-PHP/blob/master/ApplicationInsights/Tests/Channel/Contracts/Utils_Test.php#L27 so it fails in PHP 7.1 because of https://wiki.php.net/rfc/invalid_strings_in_arithmetic

Solution is to check we have something numeric for operations