### PR TITLE
Add the ability to track throwables, not just exceptions

### DIFF
--- a/ApplicationInsights/Channel/Telemetry_Channel.php
+++ b/ApplicationInsights/Channel/Telemetry_Channel.php
@@ -209,7 +209,7 @@ class Telemetry_Channel
                 $options
             );
 
-            if($sendAsync && method_exists($this->_client, 'sendAsync'))
+            if ($sendAsync && method_exists($this->_client, 'sendAsync'))
             {
                 $response = $this->_client->postAsync($this->_endpointUrl, $options);
             }

--- a/ApplicationInsights/Telemetry_Client.php
+++ b/ApplicationInsights/Telemetry_Client.php
@@ -213,11 +213,11 @@ class Telemetry_Client
 
     /**
      * Sends an Exception_Data to the Application Insights service.
-     * @param \Throwable $ex The exception to send
+     * @param \Exception|\Throwable $ex The exception/throwable to send
      * @param array $properties An array of name to value pairs. Use the name as the index and any string as the value.
      * @param array $measurements An array of name to double pairs. Use the name as the index and any double as the value.
      */
-    public function trackException(\Throwable $ex, $properties = NULL, $measurements = NULL)
+    public function trackException($ex, $properties = NULL, $measurements = NULL)
     {
         $details = new Channel\Contracts\Exception_Details();
         $details->setId(1);

--- a/ApplicationInsights/Telemetry_Client.php
+++ b/ApplicationInsights/Telemetry_Client.php
@@ -77,7 +77,7 @@ class Telemetry_Client
      * Sends an Metric_Data to the Application Insights service.
      * @param string $name Name of the metric.
      * @param double $value Value of the metric.
-     * @param \ApplicationInsights\Channel\Data_Point_Type::Value $type The type of value being sent.
+     * @param int $type The type of value being sent. Found: \ApplicationInsights\Channel\Contracts\Data_Point_Type::Value
      * @param int $count The number of samples.
      * @param double $min The minimum of the samples.
      * @param double $max The maximum of the samples.
@@ -130,7 +130,7 @@ class Telemetry_Client
     /**
      * Sends an Message_Data to the Application Insights service.
      * @param string $message The trace message.
-     * @param \ApplicationInsights\Channel\Contracts\Message_SeverityLevel::Value $severityLevel The severity level of the message.
+     * @param string $severityLevel The severity level of the message. Found: \ApplicationInsights\Channel\Contracts\Message_Severity_Level::Value
      * @param array $properties An array of name to value pairs. Use the name as the index and any string as the value.
      */
     public function trackMessage($message, $severityLevel = NULL, $properties = NULL)
@@ -213,11 +213,11 @@ class Telemetry_Client
 
     /**
      * Sends an Exception_Data to the Application Insights service.
-     * @param \Exception $ex The exception to send
+     * @param \Throwable $ex The exception to send
      * @param array $properties An array of name to value pairs. Use the name as the index and any string as the value.
      * @param array $measurements An array of name to double pairs. Use the name as the index and any double as the value.
      */
-    public function trackException(\Exception $ex, $properties = NULL, $measurements = NULL)
+    public function trackException(\Throwable $ex, $properties = NULL, $measurements = NULL)
     {
         $details = new Channel\Contracts\Exception_Details();
         $details->setId(1);
@@ -279,7 +279,7 @@ class Telemetry_Client
     /**
      * Sends an Dependency_Data to the Application Insights service.
      * @param string $name Name of the dependency.
-     * @param \ApplicationInsights\Channel\Dependency_Type::Value $type The Dependency type of value being sent.
+     * @param int $type The Dependency type of value being sent. Found: \ApplicationInsights\Channel\Contracts\Dependency_Type::Value
      * @param string $commandName Command/Method of the dependency.
      * @param int $startTime The timestamp at which the request started.
      * @param int $durationInMilliseconds The duration, in milliseconds, of the request.

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -76,14 +76,17 @@ class Telemetry_Client_Test extends TestCase
      */
     public function testGuzzleClientOverrideConstructor()
     {
-        $stack = \GuzzleHttp\HandlerStack::create(new \GuzzleHttp\Handler\CurlMultiHandler());
-        $client = new \GuzzleHttp\Client(['handler' => $stack]);
-        $telemetryChannel = new \ApplicationInsights\Channel\Telemetry_Channel('http://www.foo.com', $client);
-        $telemetryClient = new \ApplicationInsights\Telemetry_Client(null, $telemetryChannel);
-        $this->assertEquals(
-            $telemetryClient->getChannel()->GetClient()->getConfig('handler'),
-            \GuzzleHttp\HandlerStack::create(new \GuzzleHttp\Handler\CurlMultiHandler())
-        );
+        if (class_exists('\GuzzleHttp\Client') == true) {
+            $client = new \GuzzleHttp\Client(['base_uri' => "http://www.foo2.com"]);
+            $telemetryChannel = new \ApplicationInsights\Channel\Telemetry_Channel('/what', $client);
+            $telemetryClient = new \ApplicationInsights\Telemetry_Client(null, $telemetryChannel);
+            $this->assertEquals($telemetryClient->getChannel()->GetClient()->getConfig('base_uri'),
+                "http://www.foo2.com");
+        }
+        else
+        {
+            $this->markTestSkipped("\GuzzleHttp\Client does not exist");
+        }
     }
 
     /**

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -77,11 +77,11 @@ class Telemetry_Client_Test extends TestCase
     public function testGuzzleClientOverrideConstructor()
     {
         if (class_exists('\GuzzleHttp\Client') == true) {
-            $client = new \GuzzleHttp\Client(['base_uri' => "http://www.foo2.com"]);
+            $baseUrl = "http://www.foo2.com";
+            $client = new \GuzzleHttp\Client(['base_uri' => $baseUrl]);
             $telemetryChannel = new \ApplicationInsights\Channel\Telemetry_Channel('/what', $client);
             $telemetryClient = new \ApplicationInsights\Telemetry_Client(null, $telemetryChannel);
-            $this->assertEquals($telemetryClient->getChannel()->GetClient()->getConfig('base_uri'),
-                "http://www.foo2.com");
+            $this->assertEquals($telemetryClient->getChannel()->GetClient(), new \GuzzleHttp\Client(['base_uri' => $baseUrl]));
         }
         else
         {


### PR DESCRIPTION
Clean up some documentation and whitespace.
Fix test that fails for php 5.4 to skip if guzzle client does not exist. https://travis-ci.org/Microsoft/ApplicationInsights-PHP/jobs/379467584