### PR TITLE
Sergkanz/support setting internal context

### DIFF
--- a/ApplicationInsights/Channel/Telemetry_Channel.php
+++ b/ApplicationInsights/Channel/Telemetry_Channel.php
@@ -127,10 +127,6 @@ class Telemetry_Channel
         $envelope->setName($data->getEnvelopeTypeName());
         $envelope->setTime(Contracts\Utils::returnISOStringForTime());
 
-        // Set the SDK version
-        $internalContext = new Contracts\Internal();
-        $internalContext->setSdkVersion('php:0.3.2');
-
         // The instrumentation key to use
         $envelope->setInstrumentationKey($telemetryContext->getInstrumentationKey());
 
@@ -141,7 +137,7 @@ class Telemetry_Channel
                     $telemetryContext->getOperationContext()->jsonSerialize(),
                     $telemetryContext->getSessionContext()->jsonSerialize(),
                     $telemetryContext->getUserContext()->jsonSerialize(),
-                    $internalContext->jsonSerialize()));
+                    $telemetryContext->getInternalContext()->jsonSerialize()));
 
         // Merge properties from global context to local context
         $contextProperties = $telemetryContext->getProperties();

--- a/ApplicationInsights/Telemetry_Context.php
+++ b/ApplicationInsights/Telemetry_Context.php
@@ -71,7 +71,7 @@ class Telemetry_Context
         $this->_locationContext = new Channel\Contracts\Location();
         $this->_operationContext = new Channel\Contracts\Operation();
         $this->_sessionContext = new Channel\Contracts\Session();
-        $this->$_internalContext = new Channel\Contracts\Internal();
+        $this->_internalContext = new Channel\Contracts\Internal();
         $this->_properties = array();
         
         // Initialize user id
@@ -88,7 +88,7 @@ class Telemetry_Context
             $this->_locationContext->setIp($_SERVER['REMOTE_ADDR']);
         }
 
-        $this->$_internalContext->setSdkVersion('php:0.4.3');
+        $this->_internalContext->setSdkVersion('php:0.4.3');
     }
     
     /**
@@ -209,16 +209,16 @@ class Telemetry_Context
     }
     
     /**
-     * Set internal context object. Allows you to set internal details for troubleshooting.
-     * @param \ApplicationInsights\Channel\Contracts\Internal $internalContext
+     * Set session context object. Allows you to set properties that will be attached to all telemetry about the session.
+     * @param \ApplicationInsights\Channel\Contracts\Session $sessionContext
      */
-    public function setInternalContext(Channel\Contracts\Internal $internalContext)
+    public function setSessionContext(Channel\Contracts\Session $sessionContext)
     {
-        $this->_internalContext = $internalContext;
+        $this->_sessionContext = $sessionContext;
     }
     
     /**
-     * The internal context object. Allows you to set internal details for troubleshooting.
+     * The session context object. Allows you to set internal details for troubleshooting.
      * @return \ApplicationInsights\Channel\Contracts\Internal 
      */
     public function getInternalContext()
@@ -227,12 +227,12 @@ class Telemetry_Context
     }
     
     /**
-     * Set session context object. Allows you to set properties that will be attached to all telemetry about the session.
-     * @param \ApplicationInsights\Channel\Contracts\Session $sessionContext
+     * Set session context object. Allows you to set internal details for troubleshooting.
+     * @param \ApplicationInsights\Channel\Contracts\Internal $internalContext
      */
-    public function setSessionContext(Channel\Contracts\Session $sessionContext)
+    public function setInternalContext(Channel\Contracts\Internal $internalContext)
     {
-        $this->_sessionContext = $sessionContext;
+        $this->_internalContext = $internalContext;
     }
 
     /**

--- a/ApplicationInsights/Telemetry_Context.php
+++ b/ApplicationInsights/Telemetry_Context.php
@@ -47,6 +47,12 @@ class Telemetry_Context
      * @var \ApplicationInsights\Channel\Contracts\Session
      */
     private $_sessionContext;
+
+    /**
+     * The internal context
+     * @var \ApplicationInsights\Channel\Contracts\Internal
+     */
+    private $_internalContext;
     
     /**
      * Additional custom properties array.
@@ -65,6 +71,7 @@ class Telemetry_Context
         $this->_locationContext = new Channel\Contracts\Location();
         $this->_operationContext = new Channel\Contracts\Operation();
         $this->_sessionContext = new Channel\Contracts\Session();
+        $this->$_internalContext = new Channel\Contracts\Internal();
         $this->_properties = array();
         
         // Initialize user id
@@ -80,6 +87,8 @@ class Telemetry_Context
         {
             $this->_locationContext->setIp($_SERVER['REMOTE_ADDR']);
         }
+
+        $this->$_internalContext->setSdkVersion('php:0.4.3');
     }
     
     /**
@@ -200,6 +209,24 @@ class Telemetry_Context
     }
     
     /**
+     * Set internal context object. Allows you to set internal details for troubleshooting.
+     * @param \ApplicationInsights\Channel\Contracts\Internal $internalContext
+     */
+    public function setInternalContext(Channel\Contracts\Internal $internalContext)
+    {
+        $this->_internalContext = $internalContext;
+    }
+    
+    /**
+     * The internal context object. Allows you to set internal details for troubleshooting.
+     * @return \ApplicationInsights\Channel\Contracts\Internal 
+     */
+    public function getInternalContext()
+    {
+        return $this->_internalContext;
+    }
+    
+    /**
      * Set session context object. Allows you to set properties that will be attached to all telemetry about the session.
      * @param \ApplicationInsights\Channel\Contracts\Session $sessionContext
      */
@@ -207,7 +234,7 @@ class Telemetry_Context
     {
         $this->_sessionContext = $sessionContext;
     }
-    
+
     /**
      * Get the additional custom properties array.
      * @return array Additional properties (name/value pairs) to append as custom properties to all telemetry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.4.3
+
+- Support for internal context and override of SDK version.
+
+## 0.4.2
+
+- Changelog started after this version.

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -238,7 +238,7 @@ class Telemetry_Client_Test extends TestCase
     }
 
     /**
-     * Tests that sdk version can be overriden
+     * Tests that sdk version can be overridden
      */
     public function testPluginCanOverrideSdkVersion()
     {

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -238,6 +238,22 @@ class Telemetry_Client_Test extends TestCase
     }
 
     /**
+     * Tests that sdk version can be overriden
+     */
+    public function testPluginCanOverrideSdkVersion()
+    {
+        $telemetryClient = new \ApplicationInsights\Telemetry_Client();
+
+        $context = $telemetryClient->getContext()->getInternalContext();
+
+        $this->assertNotNull($context);
+        $this->assertNotNull($context->getSdkVersion());
+        $context->setSdkVersion("version");
+        $this->assertEquals("version", $context->getSdkVersion());
+    }
+
+
+    /**
      * Removes machine specific data from exceptions.
      * @param array $queue The queue of items
      * @return array


### PR DESCRIPTION
Allow to override the sdkVersion for wordpress plugin. This way one can tell whether telemetry collected via direct call to PHP SDK or automatically generated by WordPress plugin