### PR TITLE
Add default operation id on client creation

### DIFF
--- a/ApplicationInsights/Telemetry_Context.php
+++ b/ApplicationInsights/Telemetry_Context.php
@@ -88,6 +88,10 @@ class Telemetry_Context
         // Initialize session id
         $currentSession = new Current_Session();
         $this->_sessionContext->setId($currentSession->id);
+
+        // Initialize the operation id
+        $operationId = \ApplicationInsights\Channel\Contracts\Utils::returnGuid();
+        $this->_operationContext->setId($operationId);
         
         // Initialize client ip
         if (array_key_exists('REMOTE_ADDR', $_SERVER) && sizeof(explode('.', $_SERVER['REMOTE_ADDR'])) >= 4)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,21 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 >**Note**: before you can send data to you will need an instrumentation key. Please see the [Getting an Application Insights Instrumentation Key](https://github.com/Microsoft/AppInsights-Home/wiki#getting-an-application-insights-instrumentation-key) section for more information.
 
 
-**Initializing the client and setting the instrumentation key**
+**Initializing the client and setting the instrumentation key and other optional configurations**
 ```php
 $telemetryClient = new \ApplicationInsights\Telemetry_Client();
-$telemetryClient->getContext()->setInstrumentationKey('YOUR INSTRUMENTATION KEY');
+$context = $telemetryClient->getContext();
+
+// Necessary
+$context->setInstrumentationKey('YOUR INSTRUMENTATION KEY');
+
+// Optional
+$context->getSessionContext()->setId(session_id());
+$context->getUserContext()->setId('YOUR USER ID');
+$context->getApplicationContext()->setVer('YOUR VERSION');
+$context->getLocationContext()->setIp('YOUR IP');
+
+// Start tracking
 $telemetryClient->trackEvent('name of your event');
 $telemetryClient->flush();
 ```
@@ -158,5 +169,13 @@ $telemetryClient->flush();
 **Sending any other kind dependency telemetry item**
 ```php
 $telemetryClient->trackDependency('Name of operation', "service", 'Arguments', time(), 23, true);
+$telemetryClient->flush();
+```
+
+**Changing the operation id (which links actions together)**
+```php
+$telemetryClient->trackMetric('interestingMetric', 10);
+$telemetryClient->getContext()->getOperationContext()->setId(\ApplicationInsights\Channel\Contracts\Utils::returnGuid())
+$telemetryClient->trackMetric('differentOperationMetric', 11);
 $telemetryClient->flush();
 ```

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -108,7 +108,7 @@ class Telemetry_Client_Test extends TestCase
     public function testConstructor()
     {
         $telemetryClient = new \ApplicationInsights\Telemetry_Client();
-        $this->assertEquals($telemetryClient->getContext(), new \ApplicationInsights\Telemetry_Context());
+        $this->assertNotNull($telemetryClient->getContext());
         $this->assertEquals($telemetryClient->getChannel(), new \ApplicationInsights\Channel\Telemetry_Channel());
     }
 

--- a/Tests/Telemetry_Context_Test.php
+++ b/Tests/Telemetry_Context_Test.php
@@ -75,6 +75,7 @@ class Telemetry_Context_Test extends TestCase
     {
         $telemetryContext = new \ApplicationInsights\Telemetry_Context();
         $context = $telemetryContext->getOperationContext();
+        $this->assertNotEmpty($context->getId());
         $telemetryContext->setOperationContext(Utils::getSampleOperationContext());
         $context = $telemetryContext->getOperationContext();
         $this->assertEquals($context, Utils::getSampleOperationContext());


### PR DESCRIPTION
When I started using this library I didn't know that you needed to set the operation id in order to link calls. I added it by default since I'm not sure anyone would want this without it. I also updated the documentation to be more clear about the other possible options.

* updated test
* README updated with more examples of setting different context configurations and changing operation id
* operation id is automatically generated as a guid on context creation