### PR TITLE
Add support for start times in microseconds.

### DIFF
--- a/ApplicationInsights/Channel/Contracts/Utils.php
+++ b/ApplicationInsights/Channel/Contracts/Utils.php
@@ -84,15 +84,13 @@ class Utils
      * @return string
      */
     public static function returnISOStringForTime($time = null)
-    {
+    {				
         if ($time == NULL)
         {
-            return gmdate('c') . 'Z';
+					$time = microtime(true);
         }
-        else
-        {
-            return gmdate('c', $time) . 'Z';
-        }
+				$microseconds = substr(sprintf('%06d', round($time-floor($time), 6)*1000000), 0, 6);
+				gmdate("Y-m-d\TH:i:s.", $time).$microseconds.'+00:00Z';     //iso 8601 GMT with microseconds
     }
     
     /**

--- a/Tests/Channel/Contracts/Utils_Test.php
+++ b/Tests/Channel/Contracts/Utils_Test.php
@@ -30,4 +30,11 @@ class Utils_Test extends TestCase
         $this->assertEquals(Utils::convertMillisecondsToTimeSpan(-1), "00:00:00.000", "invalid input");
 
     }
+    public function returnISOStringForTime()
+    {
+				$date = (new DateTime("2004-02-12T15:19:21+00:00"))->getTimestamp();
+        $this->assertEquals(Utils::returnISOStringForTime($date), "2004-02-12T15:19:21.000000+00:00Z");
+        $this->assertEquals(Utils::returnISOStringForTime($date+0.1), "2004-02-12T15:19:21.100000+00:00Z", "milliseconds digit 1");
+        $this->assertEquals(Utils::returnISOStringForTime($date+0.999999), "2004-02-12T15:19:21.999999+00:00Z", "rounding error");
+    }
 }

--- a/Tests/Channel/Contracts/Utils_Test.php
+++ b/Tests/Channel/Contracts/Utils_Test.php
@@ -30,7 +30,7 @@ class Utils_Test extends TestCase
         $this->assertEquals(Utils::convertMillisecondsToTimeSpan(-1), "00:00:00.000", "invalid input");
 
     }
-    public function returnISOStringForTime()
+    public function testReturnISOStringForTime()
     {
 				$date = (new DateTime("2004-02-12T15:19:21+00:00"))->getTimestamp();
         $this->assertEquals(Utils::returnISOStringForTime($date), "2004-02-12T15:19:21.000000+00:00Z");


### PR DESCRIPTION
This fixes #72.