### PR TITLE
Allow us to use this package on newer applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,13 @@ php:
   - "7.4"
   - nightly
 
+matrix:
+  allow_failures:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: nightly
+
 script:
   - vendor/bin/phpunit -c phpunit.xml Tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: php
 install: composer install
 php:
+  - "5.4"
+  - "5.5"
+  - "5.6"
+  - "7.0"
   - "7.1"
   - "7.2"
   - "7.3"
   - "7.4"
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 script:
-  - phpunit -c phpunit.xml Tests/
+  - vendor/bin/phpunit -c phpunit.xml Tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: php
 install: composer install
 php:
-  - "5.4"
-  - "5.5"
-  - "5.6"
-  - "7.0"
+  - "7.1"
+  - "7.2"
+  - "7.3"
+  - "7.4"
   - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
 script:
   - phpunit -c phpunit.xml Tests/

--- a/Tests/Current_Session_Test.php
+++ b/Tests/Current_Session_Test.php
@@ -12,7 +12,7 @@ class Current_Session_Test extends TestCase
     private $sessionCreatedTime;
     private $sessionLastRenewedTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->sessionId = \ApplicationInsights\Channel\Contracts\Utils::returnGuid();
         $this->sessionCreatedTime = time();
@@ -20,7 +20,7 @@ class Current_Session_Test extends TestCase
         Utils::setSessionCookie($this->sessionId, $this->sessionCreatedTime, $this->sessionLastRenewedTime);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Utils::clearSessionCookie();
     }

--- a/Tests/Current_User_Test.php
+++ b/Tests/Current_User_Test.php
@@ -10,13 +10,13 @@ class Current_User_Test extends TestCase
 {
     private $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->userId = \ApplicationInsights\Channel\Contracts\Utils::returnGuid();
         Utils::setUserCookie($this->userId);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Utils::clearUserCookie();
     }

--- a/Tests/Telemetry_Client_Test.php
+++ b/Tests/Telemetry_Client_Test.php
@@ -10,7 +10,7 @@ class Telemetry_Client_Test extends TestCase
 {
     private $_telemetryClient;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_telemetryClient = new \ApplicationInsights\Telemetry_Client();
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=5.0 <=6.3.3"
+        "guzzlehttp/guzzle": "~5|~6"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8|~9",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/guzzle": ">=5.0 <=6.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.36",
+        "phpunit/phpunit": "~5|~6|~7|~8|~9",
         "evert/phpdoc-md" : "~0.0.7"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,24 @@
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="Tests/Bootstrap.php">
-  bootstrap="/Tests/Bootstrap.php"
-  cacheTokens="false"
-  colors="false"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  forceCoversAnnotation="false"
-  mapTestClassNameToCoveredClassName="false"
-  printerClass="PHPUnit_TextUI_ResultPrinter"
-  <!--printerFile="/path/to/ResultPrinter.php"-->
-  processIsolation="false"
-  stopOnError="false"
-  stopOnFailure="false"
-  stopOnIncomplete="false"
-  stopOnSkipped="false"
-  testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-  <!--testSuiteLoaderFile="/path/to/StandardTestSuiteLoader.php"-->
-  timeoutForSmallTests="1"
-  timeoutForMediumTests="10"
-  timeoutForLargeTests="60"
-  strict="false"
-  verbose="true"
-  <!-- ... --></phpunit>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        bootstrap="Tests/Bootstrap.php"
+        cacheTokens="false"
+        colors="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        timeoutForSmallTests="1"
+        timeoutForMediumTests="10"
+        timeoutForLargeTests="60"
+        verbose="true"
+>
+</phpunit>


### PR DESCRIPTION
I wasn't able to install this package on a Laravel 7 application and I believe anyone relying on Guzzle 6.5 wouldn't too.

This PR allows newer Guzzle versions to be used:

```
"guzzlehttp/guzzle": "~5|~6"
```

But I also updated the test suite to use newer PHPUnit (from version 5 to 9). Unfortunately [PHP 7.0 hit end-of-life some](https://www.php.net/supported-versions.php) some time ago, but PHP 7.1 (which also hit EOL) is still being supported by tests.